### PR TITLE
fix hostname starting with numbers

### DIFF
--- a/pyModbusTCP/utils.py
+++ b/pyModbusTCP/utils.py
@@ -313,7 +313,7 @@ def valid_host(host_str):
     except socket.error:
         pass
     # valid hostname ?
-    if re.match(r'^[a-zA-Z][a-zA-Z0-9.\-]+$', host_str):
+    if re.match(r'^[a-zA-Z0-9][a-zA-Z0-9.\-]+$', host_str):
         return True
     # on invalid host
     return False


### PR DESCRIPTION
Hello,

Had this particular case where I needed to expose my Modbus server to the internet.
Took the fastest way, with Ngrok, but its hostname (usually) starts with a digit, si I couldn't use the client. (Had to ping, and grab the IP)

Thanks for your work!
Quentin